### PR TITLE
Add API interfaces

### DIFF
--- a/unchained-api/pom.xml
+++ b/unchained-api/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>unchained</groupId>
+        <artifactId>unchained-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../unchained-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>unchained-api</artifactId>
+
+    <name>Unchained: API</name>
+
+</project>

--- a/unchained-api/src/main/java/unchained/ApplicationContext.java
+++ b/unchained-api/src/main/java/unchained/ApplicationContext.java
@@ -1,0 +1,7 @@
+package unchained;
+
+/**
+ * This interface encapsulates the context that carries application-wide objects, dependencies, and properties.
+ */
+public interface ApplicationContext extends Context<ApplicationLifecycle> {
+}

--- a/unchained-api/src/main/java/unchained/ApplicationLifecycle.java
+++ b/unchained-api/src/main/java/unchained/ApplicationLifecycle.java
@@ -1,0 +1,20 @@
+package unchained;
+
+/**
+ * This interface encapsulates the lifecycle of an application.
+ */
+public interface ApplicationLifecycle extends Lifecycle {
+
+    /**
+     * TODO
+     */
+    void start();
+
+    /**
+     * Stops the execution of the application from this point onward. After calling this method, the application stops
+     * processing incoming requests. The implementation has the liberty to release its allocated resources. Hence, this
+     * action might be irreversible.
+     */
+    void stop();
+
+}

--- a/unchained-api/src/main/java/unchained/ChainContext.java
+++ b/unchained-api/src/main/java/unchained/ChainContext.java
@@ -1,0 +1,24 @@
+package unchained;
+
+/**
+ * This interface encapsulates a context which can be used to carry execution-wide properties and chain-specific
+ * information/metadata throughout the life of a chain of an input/output command as it is being handled by
+ * middleware.
+ *
+ * @param <L> the lifecycle type.
+ * @param <C> the context type.
+ */
+public interface ChainContext<
+    L extends ChainLifecycle,
+    C extends ChainContext<L, C>> extends Context<L> {
+
+    /**
+     * Sets the property to the given value.
+     *
+     * @param property the property name.
+     * @param value the value.
+     * @return the context itself to use for chaining method calls.
+     */
+    C property(String property, Object value);
+
+}

--- a/unchained-api/src/main/java/unchained/ChainContext.java
+++ b/unchained-api/src/main/java/unchained/ChainContext.java
@@ -9,8 +9,9 @@ package unchained;
  * @param <C> the context type.
  */
 public interface ChainContext<
-    L extends ChainLifecycle,
-    C extends ChainContext<L, C>> extends Context<L> {
+    C extends ChainContext<C, L>,
+    L extends ChainLifecycle
+    > extends Context<L> {
 
     /**
      * Sets the property to the given value.

--- a/unchained-api/src/main/java/unchained/ChainLifecycle.java
+++ b/unchained-api/src/main/java/unchained/ChainLifecycle.java
@@ -1,0 +1,14 @@
+package unchained;
+
+/**
+ * This interface encapsulates the lifecycle of an I/O operation as it is being handled by a chain.
+ */
+public interface ChainLifecycle extends Lifecycle {
+
+    /**
+     * Stops the execution of the chain from this point onward. The process will terminate immediately and the outcome
+     * will be communicated back to the client.
+     */
+    void stop();
+
+}

--- a/unchained-api/src/main/java/unchained/CompositeMiddleware.java
+++ b/unchained-api/src/main/java/unchained/CompositeMiddleware.java
@@ -10,15 +10,16 @@ package unchained;
  * @param <O>
  * @param <M>
  * @param <Q>
+ * @param <H>
  */
 public interface CompositeMiddleware<
-    W extends CompositeMiddleware<W, L, C, I, O, M, Q>,
+    W extends CompositeMiddleware<W, L, C, I, O, M, Q, H>,
     L extends ChainLifecycle,
     C extends ChainContext<L, C>,
     I extends Input<L, C>,
     O extends Output<L, C, I>,
-    M extends Matcher<C, I>,
-    Q> extends Middleware<L, C, I, O, Q> {
+    M extends Matcher<C, I, H>,
+    Q, H> extends Middleware<L, C, I, O, Q> {
 
     /**
      * TODO: doc

--- a/unchained-api/src/main/java/unchained/CompositeMiddleware.java
+++ b/unchained-api/src/main/java/unchained/CompositeMiddleware.java
@@ -1,0 +1,35 @@
+package unchained;
+
+/**
+ * TODO: doc
+ *
+ * @param <W>
+ * @param <L>
+ * @param <C>
+ * @param <I>
+ * @param <O>
+ * @param <M>
+ * @param <Q>
+ */
+public interface CompositeMiddleware<
+    W extends CompositeMiddleware<W, L, C, I, O, M, Q>,
+    L extends ChainLifecycle,
+    C extends ChainContext<L, C>,
+    I extends Input<L, C>,
+    O extends Output<L, C, I>,
+    M extends Matcher<C, I>,
+    Q> extends Middleware<L, C, I, O, Q> {
+
+    /**
+     * TODO: doc
+     *
+     * @param matcher
+     * @param first
+     * @param rest
+     * @param <N>
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    <N extends Middleware<L, C, I, O, ?>> W use(M matcher, N first, N... rest);
+
+}

--- a/unchained-api/src/main/java/unchained/CompositeMiddleware.java
+++ b/unchained-api/src/main/java/unchained/CompositeMiddleware.java
@@ -15,11 +15,12 @@ package unchained;
 public interface CompositeMiddleware<
     W extends CompositeMiddleware<W, L, C, I, O, M, Q, H>,
     L extends ChainLifecycle,
-    C extends ChainContext<L, C>,
+    C extends ChainContext<C, L>,
     I extends Input<L, C>,
     O extends Output<L, C, I>,
     M extends Matcher<C, I, H>,
-    Q, H> extends Middleware<L, C, I, O, Q> {
+    Q,
+    H> extends Middleware<L, C, I, O, Q> {
 
     /**
      * TODO: doc

--- a/unchained-api/src/main/java/unchained/Configuration.java
+++ b/unchained-api/src/main/java/unchained/Configuration.java
@@ -1,0 +1,235 @@
+package unchained;
+
+import java.util.Set;
+
+/**
+ * This interface encapsulates a malleable configuration which contains arbitrary values.
+ *
+ * @param <C> the configuration type.
+ */
+public interface Configuration<C extends Configuration<C>> {
+
+    /**
+     * This interface represents a configuration option definition, which lets us do things like statically binding
+     * the type of an option, and provide idiomatic option value default definitions without imposing upon the
+     * implementation of the configuration classes.
+     *
+     * @param <T> the static type of this option.
+     */
+    interface Option<T> {
+
+        /**
+         * Returns the default value of this option.
+         *
+         * @return the default value associated with this option.
+         */
+        default T defaultValue() {
+            return null;
+        }
+
+        /**
+         * Returns the key of this option.
+         *
+         * @return the key associated with this option.
+         */
+        String key();
+
+    }
+
+    /**
+     * Returns configuration keys.
+     *
+     * @return the keys for which this configuration has a configuration value.
+     */
+    Set<String> keys();
+
+    /**
+     * Determines if a configuration key has a corresponding value.
+     *
+     * @param key the key to check.
+     * @return {@code true} if the key in question has been configured.
+     */
+    boolean has(String key);
+
+    /**
+     * Determines if a configuration option has a corresponding value.
+     *
+     * @param option the option to check.
+     * @return {@code true} if the key in question has been configured.
+     */
+    default boolean has(Option<?> option) {
+        return has(option.key());
+    }
+
+    /**
+     * Checks to see if a given option is enabled. Note that if the option is present but is a non-{@code boolean}
+     * option, this can cause an error. To check whether or not a configuration value has been provided for a given
+     * key, use {@link #has(String)} instead.
+     *
+     * @param key the key to check for.
+     * @return {@code true} if the key is set to {@code true}.
+     */
+    default boolean enabled(String key) {
+        return has(key) && Boolean.TRUE.equals(get(key));
+    }
+
+    /**
+     * Checks to see if a given option is enabled. Note that if the option is present but is a non-{@code boolean}
+     * option, this can cause an error. To check whether or not a configuration value has been provided for a given
+     * key, use {@link #has(Option)} instead.
+     *
+     * @param option the option to check for.
+     * @return {@code true} if the key is set to {@code true}.
+     */
+    default boolean enabled(Option<?> option) {
+        return enabled(option.key());
+    }
+
+    /**
+     * Checks to see if a given option is disabled. Note that if the option is present but is a non-{@code boolean}
+     * option, this can cause an error. To check whether or not a configuration value has been provided for a given
+     * key, use {@link #has(String)} instead.
+     *
+     * @param key the key to check for.
+     * @return {@code true} if the key is set to {@code false}.
+     */
+    default boolean disabled(String key) {
+        return !enabled(key);
+    }
+
+    /**
+     * Checks to see if a given option is disabled. Note that if the option is present but is a non-{@code boolean}
+     * option, this can cause an error. To check whether or not a configuration value has been provided for a given
+     * key, use {@link #has(Option)} instead.
+     *
+     * @param option the option to check for.
+     * @return {@code true} if the key is set to {@code false}.
+     */
+    default boolean disabled(Option<?> option) {
+        return !enabled(option);
+    }
+
+    /**
+     * Enables the provided key by setting it to {@code true}.
+     *
+     * @param key the key to enable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C enable(String key) {
+        return set(key, true);
+    }
+
+    /**
+     * Enables the provided option by setting it to {@code true}.
+     *
+     * @param option the option to enable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C enable(Option<?> option) {
+        return set(option, true);
+    }
+
+    /**
+     * Disable the provided key by setting it to {@code false}.
+     *
+     * @param key the key to disable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C disable(String key) {
+        return set(key, false);
+    }
+
+    /**
+     * Disable the provided option by setting it to {@code false}.
+     *
+     * @param option the option to disable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C disable(Option<?> option) {
+        return set(option, false);
+    }
+
+    /**
+     * Returns the value of the given key, or {@code null} if no such key exists.
+     *
+     * @param key the key.
+     * @param <E> the type.
+     * @return the value or {@code null} if it was never configured.
+     */
+    default <E> E get(String key) {
+        return get(key, null);
+    }
+
+    /**
+     * <p>Returns the value of the given option, or the corresponding default value for this option if it was never
+     * defined.</p>
+     *
+     * <p>This method does not provide any sort of deserialization. Type-casting is done via coercion; i.e. if a
+     * value is stored using a type, but read using another, incompatible type, an exception will occur.</p>
+     *
+     * @param option the option.
+     * @param <E> the type.
+     * @return the value or the default value configured for the option.
+     *
+     * @see Option#defaultValue()
+     */
+    default <E> E get(Option<E> option) {
+        return get(option.key(), option.defaultValue());
+    }
+
+    /**
+     * Returns the configured value for this key, or the provided default value if it was never configured.
+     *
+     * @param key the key.
+     * @param defaultValue the default value.
+     * @param <E> the type.
+     * @return the configured value or the provided default.
+     */
+    <E> E get(String key, E defaultValue);
+
+    /**
+     * Changes the value of the provided key.
+     *
+     * @param key the key.
+     * @param value the value.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    C set(String key, Object value);
+
+    /**
+     * Sets the value of the provided option to the given value.
+     *
+     * @param option the option.
+     * @param value the new value.
+     * @param <E> the type of the value.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default <E> C set(Option<E> option, Object value) {
+        return set(option.key(), value);
+    }
+
+    /**
+     * Removes the value of the provided key from the configuration and returns its previous value if it was ever set.
+     *
+     * @param key the key to unset.
+     * @param <E> the type of the option.
+     * @return the previously configured value of the configuration option, or {@code null} if it was never set.
+     */
+    <E> E unset(String key);
+
+    /**
+     * <p>Removes the value of the provided option from the configuration and returns its previous value if it was ever
+     * set.</p>
+     *
+     * <pThis method does not provide any sort of deserialization. Type-casting is done via coercion; i.e. if a value
+     * is stored using a type, but read using another, incompatible type, an exception will occur.</p>
+     *
+     * @param option the option to unset.
+     * @param <E> the type of the option.
+     * @return the previously configured value of the configuration option, or {@code null} if it was never set.
+     */
+    default <E> E unset(Option<?> option) {
+        return unset(option.key());
+    }
+
+}

--- a/unchained-api/src/main/java/unchained/Configuration.java
+++ b/unchained-api/src/main/java/unchained/Configuration.java
@@ -4,10 +4,8 @@ import java.util.Set;
 
 /**
  * This interface encapsulates a malleable configuration which contains arbitrary values.
- *
- * @param <C> the configuration type.
  */
-public interface Configuration<C extends Configuration<C>> {
+public interface Configuration {
 
     /**
      * This interface represents a configuration option definition, which lets us do things like statically binding
@@ -110,46 +108,6 @@ public interface Configuration<C extends Configuration<C>> {
     }
 
     /**
-     * Enables the provided key by setting it to {@code true}.
-     *
-     * @param key the key to enable.
-     * @return the configuration itself to use for chaining method calls.
-     */
-    default C enable(String key) {
-        return set(key, true);
-    }
-
-    /**
-     * Enables the provided option by setting it to {@code true}.
-     *
-     * @param option the option to enable.
-     * @return the configuration itself to use for chaining method calls.
-     */
-    default C enable(Option<?> option) {
-        return set(option, true);
-    }
-
-    /**
-     * Disable the provided key by setting it to {@code false}.
-     *
-     * @param key the key to disable.
-     * @return the configuration itself to use for chaining method calls.
-     */
-    default C disable(String key) {
-        return set(key, false);
-    }
-
-    /**
-     * Disable the provided option by setting it to {@code false}.
-     *
-     * @param option the option to disable.
-     * @return the configuration itself to use for chaining method calls.
-     */
-    default C disable(Option<?> option) {
-        return set(option, false);
-    }
-
-    /**
      * Returns the value of the given key, or {@code null} if no such key exists.
      *
      * @param key the key.
@@ -187,49 +145,4 @@ public interface Configuration<C extends Configuration<C>> {
      */
     <E> E get(String key, E defaultValue);
 
-    /**
-     * Changes the value of the provided key.
-     *
-     * @param key the key.
-     * @param value the value.
-     * @return the configuration itself to use for chaining method calls.
-     */
-    C set(String key, Object value);
-
-    /**
-     * Sets the value of the provided option to the given value.
-     *
-     * @param option the option.
-     * @param value the new value.
-     * @param <E> the type of the value.
-     * @return the configuration itself to use for chaining method calls.
-     */
-    default <E> C set(Option<E> option, Object value) {
-        return set(option.key(), value);
-    }
-
-    /**
-     * Removes the value of the provided key from the configuration and returns its previous value if it was ever set.
-     *
-     * @param key the key to unset.
-     * @param <E> the type of the option.
-     * @return the previously configured value of the configuration option, or {@code null} if it was never set.
-     */
-    <E> E unset(String key);
-
-    /**
-     * <p>Removes the value of the provided option from the configuration and returns its previous value if it was ever
-     * set.</p>
-     *
-     * <pThis method does not provide any sort of deserialization. Type-casting is done via coercion; i.e. if a value
-     * is stored using a type, but read using another, incompatible type, an exception will occur.</p>
-     *
-     * @param option the option to unset.
-     * @param <E> the type of the option.
-     * @return the previously configured value of the configuration option, or {@code null} if it was never set.
-     */
-    default <E> E unset(Option<?> option) {
-        return unset(option.key());
-    }
-
-}
+ }

--- a/unchained-api/src/main/java/unchained/Configuration.java
+++ b/unchained-api/src/main/java/unchained/Configuration.java
@@ -5,7 +5,7 @@ import java.util.Set;
 /**
  * This interface encapsulates a malleable configuration which contains arbitrary values.
  */
-public interface Configuration {
+public interface Configuration<C extends Configuration> {
 
     /**
      * This interface represents a configuration option definition, which lets us do things like statically binding

--- a/unchained-api/src/main/java/unchained/Context.java
+++ b/unchained-api/src/main/java/unchained/Context.java
@@ -1,0 +1,110 @@
+package unchained;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * This interface encapsulates a context which can be used to carry execution-wide properties
+ * and specific information/metadata throughout the life of a an operation.
+ *
+ * @param <L> the lifecycle type.
+ */
+public interface Context<L extends Lifecycle> {
+
+    /**
+     * Gives access to the lifecycle bound to this context.
+     *
+     * @return the lifecycle bound to this context.
+     */
+    L lifecycle();
+
+    /**
+     * Returns the object with the provided name.
+     *
+     * @param name the name.
+     * @param <E> the type.
+     * @return the object or {@code null} if no such object exists.
+     */
+    <E> E get(String name);
+
+    /**
+     * Returns the object with the given type.
+     *
+     * @param type the expected type.
+     * @param <E> the type.
+     * @return the object or {@code null} if no such object exists.
+     */
+    <E> E get(Class<? super E> type);
+
+    /**
+     * Returns an object with the given name and type.
+     *
+     * @param name the name.
+     * @param type the type.
+     * @param <E> the type.
+     * @return the object or {@code null} if no such object exists.
+     */
+    <E> E get(String name, Class<E> type);
+
+    /**
+     * Returns all objects of the given type.
+     *
+     * @param type the expected type.
+     * @param <E> the type.
+     * @return a collection of all objects of the given type.
+     */
+    <E> Collection<? extends E> getAll(Class<E> type);
+
+    /**
+     * Checks to see if an object with the given name can be found in this context.
+     *
+     * @param name the name to look for.
+     * @return {@code true} if the search results in at least one object.
+     */
+    boolean has(String name);
+
+    /**
+     * Checks to see if an object with the given type can be found in this context.
+     *
+     * @param type the type to look for.
+     * @return {@code true} if the search results in at least one object.
+     */
+    boolean has(Class<?> type);
+
+    /**
+     * Checks to see if an object with the given name and type can be found in this context.
+     *
+     * @param name the name to look for.
+     * @param type the type to look for.
+     * @return {@code true} if the search results in at least one object.
+     */
+    boolean has(String name, Class<?> type);
+
+    /**
+     * Returns the given property by coercing it to the expected type. Note that no type conversion
+     * or deserialization is performed; rather, the object is returned as is in the context and is
+     * only coerced to the expected return type.
+     *
+     * @param name the name of the property.
+     * @param <E> the expected type of the property.
+     * @return the value of the property or {@code null} if no such property exists.
+     * @throws ClassCastException in case the object is being coerced to the wrong type.
+     */
+    <E> E property(String name);
+
+    /**
+     * Checks to see if the named property exists in this context.
+     *
+     * @param name the name of the property.
+     * @return {@code true} in case the property of the given name exists.
+     */
+    boolean hasProperty(String name);
+
+    /**
+     * Returns list of all property names.
+     *
+     * @return the list of all property names held by this context.
+     */
+    Set<String> propertyNames();
+
+}

--- a/unchained-api/src/main/java/unchained/Input.java
+++ b/unchained-api/src/main/java/unchained/Input.java
@@ -8,7 +8,7 @@ package unchained;
  */
 public interface Input<
     L extends ChainLifecycle,
-    C extends ChainContext<L, C>> {
+    C extends ChainContext<C, L>> {
 
     /**
      * Gives access to the context associated with this input.

--- a/unchained-api/src/main/java/unchained/Input.java
+++ b/unchained-api/src/main/java/unchained/Input.java
@@ -1,0 +1,27 @@
+package unchained;
+
+/**
+ * This class represents an actionable input which is used to start off a chain.
+ *
+ * @param <L> the lifecycle type.
+ * @param <C> the context type.
+ */
+public interface Input<
+    L extends ChainLifecycle,
+    C extends ChainContext<L, C>> {
+
+    /**
+     * Gives access to the context associated with this input.
+     *
+     * @return the context associated with this input.
+     */
+    C context();
+
+    /**
+     * Indicates if the input is ready to be consumed.
+     *
+     * @return {@code true} in case the input is ready to be consumed.
+     */
+    boolean ready();
+
+}

--- a/unchained-api/src/main/java/unchained/Lifecycle.java
+++ b/unchained-api/src/main/java/unchained/Lifecycle.java
@@ -1,0 +1,23 @@
+package unchained;
+
+
+/**
+ * This interface encapsulates the lifecycle of a general process.
+ */
+public interface Lifecycle {
+
+    /**
+     * Indicates if the lifecycle is started or not.
+     *
+     * @return {@code true} if this lifecycle has already been started.
+     */
+    boolean started();
+
+    /**
+     * Indicates if the lifecycle is terminated or not.
+     *
+     * @return {@code true} if this lifecycle has already been terminated.
+     */
+    boolean stopped();
+
+}

--- a/unchained-api/src/main/java/unchained/Matcher.java
+++ b/unchained-api/src/main/java/unchained/Matcher.java
@@ -1,0 +1,45 @@
+package unchained;
+
+/**
+ * TODO: doc
+ *
+ * @param <C>
+ * @param <I>
+ */
+public interface Matcher<
+    C extends ChainContext<? extends ChainLifecycle, C>,
+    I extends Input<? extends ChainLifecycle, C>> {
+
+    /**
+     * TODO: doc
+     *
+     * @param <C>
+     * @param <I>
+     * @param <M>
+     * @param <S>
+     */
+    interface Compiler<
+        C extends ChainContext<? extends ChainLifecycle, C>,
+        I extends Input<? extends ChainLifecycle, C>,
+        M extends Matcher<C, I>,
+        S> {
+
+        /**
+         * TODO: doc
+         *
+         * @param expression
+         * @return
+         */
+        M compile(S expression);
+
+    }
+
+    /**
+     * TODO: doc
+     *
+     * @param input
+     * @return
+     */
+    boolean test(I input);
+
+}

--- a/unchained-api/src/main/java/unchained/Matcher.java
+++ b/unchained-api/src/main/java/unchained/Matcher.java
@@ -5,10 +5,12 @@ package unchained;
  *
  * @param <C>
  * @param <I>
+ * @param <E>
  */
 public interface Matcher<
     C extends ChainContext<? extends ChainLifecycle, C>,
-    I extends Input<? extends ChainLifecycle, C>> {
+    I extends Input<? extends ChainLifecycle, C>,
+    E> {
 
     /**
      * TODO: doc
@@ -17,12 +19,14 @@ public interface Matcher<
      * @param <I>
      * @param <M>
      * @param <S>
+     * @param <T>
      */
     interface Compiler<
         C extends ChainContext<? extends ChainLifecycle, C>,
         I extends Input<? extends ChainLifecycle, C>,
-        M extends Matcher<C, I>,
-        S> {
+        M extends Matcher<C, I, T>,
+        S,
+        T> {
 
         /**
          * TODO: doc
@@ -34,12 +38,20 @@ public interface Matcher<
 
     }
 
+    interface Hit<T> {
+
+        boolean matched();
+
+        T value();
+
+    }
+
     /**
      * TODO: doc
      *
      * @param input
      * @return
      */
-    boolean test(I input);
+    Hit<E> test(I input);
 
 }

--- a/unchained-api/src/main/java/unchained/Matcher.java
+++ b/unchained-api/src/main/java/unchained/Matcher.java
@@ -8,7 +8,7 @@ package unchained;
  * @param <E>
  */
 public interface Matcher<
-    C extends ChainContext<? extends ChainLifecycle, C>,
+    C extends ChainContext<C, ? extends ChainLifecycle>,
     I extends Input<? extends ChainLifecycle, C>,
     E> {
 
@@ -22,7 +22,7 @@ public interface Matcher<
      * @param <T>
      */
     interface Compiler<
-        C extends ChainContext<? extends ChainLifecycle, C>,
+        C extends ChainContext<C, ? extends ChainLifecycle>,
         I extends Input<? extends ChainLifecycle, C>,
         M extends Matcher<C, I, T>,
         S,

--- a/unchained-api/src/main/java/unchained/Middleware.java
+++ b/unchained-api/src/main/java/unchained/Middleware.java
@@ -1,0 +1,35 @@
+package unchained;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This interface defines the cornerstone of how a chain is handled. A chain of actions is ultimately a root middleware
+ * which will call to other middleware, each of which might follow suite, and so on, which essentially forms a
+ * multi-level chain of execution. This encourages writing reusable middleware that can be hooked at the appropriate
+ * juncture to provide essential functionality.
+ *
+ * @param <L>  the type of lifecycle bound to this middleware's chain.
+ * @param <C> the type of context bound to this middleware's input.
+ * @param <I> the type of input this middleware works with.
+ * @param <O> the type of output this middleware can deal with.
+ * @param <Q> the type of output for this middleware.
+ */
+public interface Middleware<
+    L extends ChainLifecycle,
+    C extends ChainContext<L, C>,
+    I extends Input<L, C>,
+    O extends Output<L, C, I>,
+    Q> {
+
+    /**
+     * Handles the incoming input and works on the input and output. This is a very generic method which will be called
+     * by the framework whenever a chain is in progress. Note that this method is asynchronous in nature.
+     *
+     * @param input the input.
+     * @param output the output.
+     * @return a future whose completion represents the completion of the middleware itself.
+     * @throws Exception in case the underlying logic causes an error.
+     */
+    CompletableFuture<Q> execute(I input, O output) throws Exception;
+
+}

--- a/unchained-api/src/main/java/unchained/Middleware.java
+++ b/unchained-api/src/main/java/unchained/Middleware.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface Middleware<
     L extends ChainLifecycle,
-    C extends ChainContext<L, C>,
+    C extends ChainContext<C, L>,
     I extends Input<L, C>,
     O extends Output<L, C, I>,
     Q> {

--- a/unchained-api/src/main/java/unchained/MutableConfiguration.java
+++ b/unchained-api/src/main/java/unchained/MutableConfiguration.java
@@ -5,7 +5,7 @@ package unchained;
  *
  * @param <C>
  */
-public interface MutableConfiguration<C extends MutableConfiguration<C>> extends Configuration {
+public interface MutableConfiguration<C extends MutableConfiguration<C>> extends Configuration<C> {
 
     /**
      * Enables the provided key by setting it to {@code true}.

--- a/unchained-api/src/main/java/unchained/MutableConfiguration.java
+++ b/unchained-api/src/main/java/unchained/MutableConfiguration.java
@@ -1,0 +1,95 @@
+package unchained;
+
+/**
+ * Mutable configuration.
+ *
+ * @param <C>
+ */
+public interface MutableConfiguration<C extends MutableConfiguration<C>> extends Configuration {
+
+    /**
+     * Enables the provided key by setting it to {@code true}.
+     *
+     * @param key the key to enable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C enable(String key) {
+        return set(key, true);
+    }
+
+    /**
+     * Enables the provided option by setting it to {@code true}.
+     *
+     * @param option the option to enable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C enable(Option<?> option) {
+        return set(option, true);
+    }
+
+    /**
+     * Disable the provided key by setting it to {@code false}.
+     *
+     * @param key the key to disable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C disable(String key) {
+        return set(key, false);
+    }
+
+    /**
+     * Disable the provided option by setting it to {@code false}.
+     *
+     * @param option the option to disable.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default C disable(Option<?> option) {
+        return set(option, false);
+    }
+
+    /**
+     * Changes the value of the provided key.
+     *
+     * @param key the key.
+     * @param value the value.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    C set(String key, Object value);
+
+    /**
+     * Sets the value of the provided option to the given value.
+     *
+     * @param option the option.
+     * @param value the new value.
+     * @param <E> the type of the value.
+     * @return the configuration itself to use for chaining method calls.
+     */
+    default <E> C set(Option<E> option, Object value) {
+        return set(option.key(), value);
+    }
+
+    /**
+     * Removes the value of the provided key from the configuration and returns its previous value if it was ever set.
+     *
+     * @param key the key to unset.
+     * @param <E> the type of the option.
+     * @return the previously configured value of the configuration option, or {@code null} if it was never set.
+     */
+    <E> E unset(String key);
+
+    /**
+     * <p>Removes the value of the provided option from the configuration and returns its previous value if it was ever
+     * set.</p>
+     *
+     * <pThis method does not provide any sort of deserialization. Type-casting is done via coercion; i.e. if a value
+     * is stored using a type, but read using another, incompatible type, an exception will occur.</p>
+     *
+     * @param option the option to unset.
+     * @param <E> the type of the option.
+     * @return the previously configured value of the configuration option, or {@code null} if it was never set.
+     */
+    default <E> E unset(Option<?> option) {
+        return unset(option.key());
+    }
+
+}

--- a/unchained-api/src/main/java/unchained/Output.java
+++ b/unchained-api/src/main/java/unchained/Output.java
@@ -1,0 +1,29 @@
+package unchained;
+
+/**
+ * This interface represents an output which is used at the end of a chain to communicate with the client.
+ *
+ * @param <L> the lifecycle type.
+ * @param <C> the context type.
+ * @param <I> the input type.
+ */
+public interface Output<
+    L extends ChainLifecycle,
+    C extends ChainContext<L, C>,
+    I extends Input<L, C>> {
+
+    /**
+     * Gives access to the input associated with this output.
+     *
+     * @return the input associated with this output.
+     */
+    I input();
+
+    /**
+     * Indicates if the output is ready to be returned.
+     *
+     * @return {@code true} in case the output is ready to be communicated back to the client.
+     */
+    boolean ready();
+
+}

--- a/unchained-api/src/main/java/unchained/Output.java
+++ b/unchained-api/src/main/java/unchained/Output.java
@@ -9,7 +9,7 @@ package unchained;
  */
 public interface Output<
     L extends ChainLifecycle,
-    C extends ChainContext<L, C>,
+    C extends ChainContext<C, L>,
     I extends Input<L, C>> {
 
     /**

--- a/unchained-api/src/main/java/unchained/http/BodyReader.java
+++ b/unchained-api/src/main/java/unchained/http/BodyReader.java
@@ -1,0 +1,21 @@
+package unchained.http;
+
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+
+public interface BodyReader {
+
+    InputStream asStream();
+
+    byte[] asBytes();
+
+    String asString();
+
+    String asString(Charset charset);
+
+    <E> E as(Class<E> type);
+
+    <E> E as(Type type);
+
+}

--- a/unchained-api/src/main/java/unchained/http/BodyWriter.java
+++ b/unchained-api/src/main/java/unchained/http/BodyWriter.java
@@ -1,0 +1,17 @@
+package unchained.http;
+
+import java.io.OutputStream;
+
+public interface BodyWriter {
+
+    OutputStream asStream();
+
+    void set(byte[] body);
+
+    void set(String body);
+
+    <E> void set(E body);
+
+    void done();
+
+}

--- a/unchained-api/src/main/java/unchained/http/HttpRequest.java
+++ b/unchained-api/src/main/java/unchained/http/HttpRequest.java
@@ -1,0 +1,29 @@
+package unchained.http;
+
+import unchained.web.Request;
+
+import java.net.InetSocketAddress;
+
+public interface HttpRequest extends Request<BodyReader> {
+
+    /**
+     * @return the HTTP method/verb associated with this request.
+     */
+    String method();
+
+    /**
+     * @return the HTTP scheme used to run this request (e.g. https).
+     */
+    String scheme();
+
+    /**
+     * @return the protocol on which this request was handled (e.g. HTTP 1.1).
+     */
+    String protocol();
+
+    /**
+     * @return the remote address of the client.
+     */
+    InetSocketAddress remote();
+
+}

--- a/unchained-api/src/main/java/unchained/http/HttpRequestHandler.java
+++ b/unchained-api/src/main/java/unchained/http/HttpRequestHandler.java
@@ -1,0 +1,18 @@
+package unchained.http;
+
+import unchained.web.RequestHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface HttpRequestHandler extends RequestHandler<BodyReader, BodyWriter, HttpRequest, HttpResponse> {
+
+    void handle(HttpRequest request, HttpResponse response);
+
+    @Override
+    default CompletableFuture<Void> execute(HttpRequest input, HttpResponse output) throws Exception {
+        return CompletableFuture
+            .allOf(input.payload(), output.payload())
+                .thenRunAsync(() -> handle(input, output));
+    }
+
+}

--- a/unchained-api/src/main/java/unchained/http/HttpResponse.java
+++ b/unchained-api/src/main/java/unchained/http/HttpResponse.java
@@ -1,0 +1,13 @@
+package unchained.http;
+
+import unchained.web.Response;
+
+public interface HttpResponse extends Response<BodyReader, BodyWriter, HttpRequest> {
+
+    int status();
+
+    String statusText();
+
+    HttpResponse status(int status, String text);
+
+}

--- a/unchained-api/src/main/java/unchained/http/ReturningHttpRequestHandler.java
+++ b/unchained-api/src/main/java/unchained/http/ReturningHttpRequestHandler.java
@@ -1,0 +1,18 @@
+package unchained.http;
+
+import unchained.web.RequestHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface ReturningHttpRequestHandler extends RequestHandler<BodyReader, BodyWriter, HttpRequest, HttpResponse> {
+
+    Object handle(HttpRequest request);
+
+    @Override
+    default CompletableFuture<Void> execute(HttpRequest input, HttpResponse output) throws Exception {
+        return CompletableFuture
+            .allOf(input.payload(), output.payload())
+            .thenRunAsync(() -> output.payload().join().set(handle(input)));
+    }
+
+}

--- a/unchained-api/src/main/java/unchained/web/Request.java
+++ b/unchained-api/src/main/java/unchained/web/Request.java
@@ -1,0 +1,92 @@
+package unchained.web;
+
+import unchained.Input;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * TODO: doc
+ *
+ * @param <T>
+ */
+public interface Request<T> extends Input<RequestLifecycle, RequestContext> {
+
+    /**
+     * TODO: doc
+     *
+     * @return
+     */
+    String uri();
+
+    /**
+     * TODO: doc
+     *
+     * @param uri
+     */
+    void uri(String uri);
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @return
+     */
+    boolean hasHeader(String name);
+
+    /**
+     *
+     * @return
+     */
+    Map<String, ?> headers();
+
+    /**
+     * TODO: doc
+     *
+     * @return
+     */
+    Set<String> headerNames();
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @param <E>
+     * @return
+     */
+    <E> E header(String name);
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @param type
+     * @param <E>
+     * @return
+     */
+    <E> E header(String name, Class<E> type);
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @param value
+     */
+    <E> E header(String name, E value);
+
+    /**
+     * TODO: doc
+     *
+     * @return
+     */
+    CompletableFuture<T> payload();
+
+    /**
+     * TODO: doc
+     *
+     * @param payload
+     */
+    void payload(T payload);
+
+}

--- a/unchained-api/src/main/java/unchained/web/RequestContext.java
+++ b/unchained-api/src/main/java/unchained/web/RequestContext.java
@@ -7,7 +7,7 @@ import java.util.concurrent.Executor;
 /**
  * TODO: doc
  */
-public interface RequestContext extends ChainContext<RequestLifecycle, RequestContext> {
+public interface RequestContext extends ChainContext<RequestContext, RequestLifecycle> {
 
     /**
      * Convenient method to get access to the {@link Executor} bound to this context.

--- a/unchained-api/src/main/java/unchained/web/RequestContext.java
+++ b/unchained-api/src/main/java/unchained/web/RequestContext.java
@@ -1,0 +1,21 @@
+package unchained.web;
+
+import unchained.ChainContext;
+
+import java.util.concurrent.Executor;
+
+/**
+ * TODO: doc
+ */
+public interface RequestContext extends ChainContext<RequestLifecycle, RequestContext> {
+
+    /**
+     * Convenient method to get access to the {@link Executor} bound to this context.
+     *
+     * @return the {@link Executor} bound to this context.
+     */
+    default Executor executor() {
+        return get(Executor.class);
+    }
+
+}

--- a/unchained-api/src/main/java/unchained/web/RequestHandler.java
+++ b/unchained-api/src/main/java/unchained/web/RequestHandler.java
@@ -1,0 +1,18 @@
+package unchained.web;
+
+import unchained.Middleware;
+
+/**
+ * TODO: doc
+ *
+ * @param <S>
+ * @param <T>
+ * @param <I>
+ * @param <O>
+ */
+public interface RequestHandler<
+    S, T,
+    I extends Request<S>,
+    O extends Response<S, T, I>> extends Middleware<RequestLifecycle, RequestContext, I, O, Void> {
+
+}

--- a/unchained-api/src/main/java/unchained/web/RequestLifecycle.java
+++ b/unchained-api/src/main/java/unchained/web/RequestLifecycle.java
@@ -1,0 +1,11 @@
+package unchained.web;
+
+import unchained.ChainLifecycle;
+
+/**
+ * This interface encapsulates the lifecycle of a request which is being handled by a chain of middlewares.
+ * Although in principle there is no significant difference between request lifecycle and the chain that
+ * is processing it, this interface provides an opportunity to define request-specific lifecycle operations.
+ */
+public interface RequestLifecycle extends ChainLifecycle {
+}

--- a/unchained-api/src/main/java/unchained/web/Response.java
+++ b/unchained-api/src/main/java/unchained/web/Response.java
@@ -1,0 +1,79 @@
+package unchained.web;
+
+import unchained.Output;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ *
+ * @param <S>
+ * @param <T>
+ * @param <I>
+ */
+public interface Response<S, T, I extends Request<S>> extends Output<RequestLifecycle, RequestContext, I> {
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @return
+     */
+    boolean hasHeader(String name);
+
+    /**
+     *
+     * @return
+     */
+    Map<String, ?> headers();
+
+    /**
+     * TODO: doc
+     *
+     * @return
+     */
+    Set<String> headerNames();
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @param <E>
+     * @return
+     */
+    <E> E header(String name);
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @param type
+     * @param <E>
+     * @return
+     */
+    <E> E header(String name, Class<E> type);
+
+    /**
+     * TODO: doc
+     *
+     * @param name
+     * @param value
+     */
+    <E> E header(String name, E value);
+
+    /**
+     * TODO: doc
+     *
+     * @return
+     */
+    CompletableFuture<T> payload();
+
+    /**
+     * TODO: doc
+     *
+     * @param payload
+     */
+    void payload(T payload);
+
+}

--- a/unchained-build/pom.xml
+++ b/unchained-build/pom.xml
@@ -14,6 +14,13 @@
 
     <name>Unchained: Build Reactor</name>
 
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <modules>
         <module>../unchained-parent</module>
         <module>../unchained-commons</module>

--- a/unchained-build/pom.xml
+++ b/unchained-build/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>../unchained-parent</module>
         <module>../unchained-commons</module>
+        <module>../unchained-api</module>
     </modules>
 
 </project>

--- a/unchained-parent/pom.xml
+++ b/unchained-parent/pom.xml
@@ -14,4 +14,11 @@
 
     <name>Unchained: Parent Module</name>
 
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
 </project>


### PR DESCRIPTION
*NOTE: This is to re-open #2 after it was closed by the force-push*

Including the high-level and low-level Java interfaces of Unchained API. The API is intended to be used by application developers. This is not the same as service provider interface (SPI) which is intended for service providers.